### PR TITLE
Add support for putenv()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ Supported annotations:
 
  * `@env` for `$_ENV`
  * `@server` for `$_SERVER` 
+ * `@putenv` for [`putenv()`](http://php.net/putenv)
 
 Global variables are set before each test case is executed,
 and brought to the original state after each test case has finished.
+The same applies to `putenv()`/`getenv()` calls.
 
 ## Installation
 
@@ -73,6 +75,7 @@ class ExampleTest extends TestCase
      * @env APP_DEBUG=0
      * @server APP_ENV=bar
      * @server APP_DEBUG=1
+     * @putenv APP_HOST=localhost
      */
     public function test_global_variables()
     {
@@ -81,6 +84,7 @@ class ExampleTest extends TestCase
         $this->assertSame('0', $_ENV['APP_DEBUG']);
         $this->assertSame('bar', $_SERVER['APP_ENV']);
         $this->assertSame('1', $_SERVER['APP_DEBUG']);
+        $this->assertSame('localhost', \getenv('APP_HOST'));
     }
 }
 ```

--- a/tests/AnnotationListenerTest.php
+++ b/tests/AnnotationListenerTest.php
@@ -11,6 +11,7 @@ use Zalas\PHPUnit\Globals\AnnotationListener;
 /**
  * @env APP_ENV=test
  * @server APP_DEBUG=0
+ * @putenv APP_HOST=localhost
  */
 class AnnotationListenerTest extends TestCase
 {
@@ -22,29 +23,35 @@ class AnnotationListenerTest extends TestCase
     /**
      * @env APP_ENV=test_foo
      * @server APP_DEBUG=1
+     * @putenv APP_HOST=dev
      */
     public function test_it_reads_global_variables_from_method_annotations()
     {
         $this->assertArraySubset(['APP_ENV' => 'test_foo'], $_ENV);
         $this->assertArraySubset(['APP_DEBUG' => '1'], $_SERVER);
+        $this->assertArraySubset(['APP_HOST' => 'dev'], \getenv());
     }
 
     public function test_it_reads_global_variables_from_class_annotations()
     {
         $this->assertArraySubset(['APP_ENV' => 'test'], $_ENV);
         $this->assertArraySubset(['APP_DEBUG' => '0'], $_SERVER);
+        $this->assertArraySubset(['APP_HOST' => 'localhost'], \getenv());
     }
 
     /**
      * @env FOO=foo
      * @server BAR=bar
+     * @putenv BAZ=baz
      */
     public function test_it_reads_additional_global_variables_from_methods()
     {
         $this->assertArraySubset(['APP_ENV' => 'test'], $_ENV);
         $this->assertArraySubset(['APP_DEBUG' => '0'], $_SERVER);
+        $this->assertArraySubset(['APP_HOST' => 'localhost'], \getenv());
         $this->assertArraySubset(['FOO' => 'foo'], $_ENV);
         $this->assertArraySubset(['BAR' => 'bar'], $_SERVER);
+        $this->assertArraySubset(['BAZ' => 'baz'], \getenv());
     }
 
     /**
@@ -52,21 +59,26 @@ class AnnotationListenerTest extends TestCase
      * @env APP_ENV=test_foo_bar
      * @server APP_DEBUG=1
      * @server APP_DEBUG=2
+     * @putenv APP_HOST=host1
+     * @putenv APP_HOST=host2
      */
     public function test_it_reads_the_latest_var_defined()
     {
         $this->assertArraySubset(['APP_ENV' => 'test_foo_bar'], $_ENV);
         $this->assertArraySubset(['APP_DEBUG' => '2'], $_SERVER);
+        $this->assertArraySubset(['APP_HOST' => 'host2'], \getenv());
     }
 
     /**
      * @env APP_ENV
      * @server APP_DEBUG
+     * @putenv APP_HOST
      */
     public function test_it_reads_empty_vars()
     {
         $this->assertArraySubset(['APP_ENV' => ''], $_ENV);
         $this->assertArraySubset(['APP_DEBUG' => ''], $_SERVER);
+        $this->assertArraySubset(['APP_HOST' => ''], \getenv());
     }
 
     public function test_it_backups_the_state()
@@ -75,9 +87,13 @@ class AnnotationListenerTest extends TestCase
 
         $_ENV['FOO'] = 'env_foo';
         $_SERVER['BAR'] = 'server_bar';
+        \putenv('FOO=putenv_foo');
+        \putenv('USER=foobar');
 
         $this->assertArrayHasKey('FOO', $_ENV);
         $this->assertArrayHasKey('BAR', $_SERVER);
+        $this->assertSame('putenv_foo', \getenv('FOO'));
+        $this->assertSame('foobar', \getenv('USER'));
     }
 
     /**
@@ -87,6 +103,9 @@ class AnnotationListenerTest extends TestCase
     {
         $this->assertArrayNotHasKey('FOO', $_ENV);
         $this->assertArrayNotHasKey('BAR', $_SERVER);
+        $this->assertFalse(\getenv('FOO'), 'It removes environment variables initialised in a test.');
+        $this->assertNotSame('foobar', \getenv('USER'), 'It restores environment variables changed in a test.');
+        $this->assertNotFalse(\getenv('USER'), 'It restores environment variables changed in a test.');
     }
 
     public function test_it_ignores_non_standard_test_cases()


### PR DESCRIPTION
Example:

```php
use PHPUnit\Framework\TestCase;

/**
 * @putenv FOO=foo
 */
class ExampleTest extends TestCase
{
    /**
     * @putenv BAR=bar
     */
    public function test_putenv()
    {
        $this->assertSame('foo', \getenv('FOO'));
        $this->assertSame('bar', \getenv('BAR'));
    }
}
```