### PR TITLE
Null coalescing for array_merge_recursive

### DIFF
--- a/src/AnnotationExtension.php
+++ b/src/AnnotationExtension.php
@@ -76,7 +76,7 @@ class AnnotationExtension implements BeforeTestHook, AfterTestHook
         $annotations = $this->parseTestMethodAnnotations($test);
 
         return \array_filter(
-            \array_merge_recursive(['env' => [], 'server' => [], 'putenv' => []], $annotations['class'], $annotations['method']),
+            \array_merge_recursive(['env' => [], 'server' => [], 'putenv' => []], $annotations['class'], $annotations['method'] ?? []),
             function (string $annotationName) {
                 return \in_array($annotationName, ['env', 'server', 'putenv']);
             },


### PR DESCRIPTION
`$annotations['method']` may be null (probably since sebastianbergmann/phpunit@c38b65c5c4447e5d8cb84cdb1781e850bd117d0c).
Test execution then crashes with the message `array_merge_recursive(): Expected parameter 3 to be an array, null given`

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

