### PR TITLE
Handle tests with @dataProvider properly

### DIFF
--- a/src/AnnotationExtension.php
+++ b/src/AnnotationExtension.php
@@ -87,6 +87,6 @@ class AnnotationExtension implements BeforeTestHook, AfterTestHook
     private function parseTestMethodAnnotations(string $test): array
     {
         // @see PHPUnit\Framework\TestCase::getAnnotations
-        return Test::parseTestMethodAnnotations(...\preg_split('/ |\:\:/', $test));
+        return Test::parseTestMethodAnnotations(...\preg_split('/ |::/', $test));
     }
 }

--- a/src/AnnotationExtension.php
+++ b/src/AnnotationExtension.php
@@ -87,6 +87,6 @@ class AnnotationExtension implements BeforeTestHook, AfterTestHook
     private function parseTestMethodAnnotations(string $test): array
     {
         // @see PHPUnit\Framework\TestCase::getAnnotations
-        return Test::parseTestMethodAnnotations(...\explode('::', $test));
+        return Test::parseTestMethodAnnotations(...\preg_split('/ |\:\:/', $test));
     }
 }

--- a/tests/AnnotationExtensionWithDataProviderTest.php
+++ b/tests/AnnotationExtensionWithDataProviderTest.php
@@ -10,11 +10,13 @@ class AnnotationExtensionWithDataProviderTest extends TestCase
     /**
      * @dataProvider provider
      */
-    public function test_it_handles_dataproviders() {
+    public function test_it_handles_dataproviders()
+    {
         $this->assertTrue(true, 'It lets the test cases run normally');
     }
 
-    public function provider() {
+    public function provider()
+    {
         // This is just a dummy data provider
         yield [1];
     }

--- a/tests/AnnotationExtensionWithDataProviderTest.php
+++ b/tests/AnnotationExtensionWithDataProviderTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class AnnotationExtensionWithDataProviderTest extends TestCase
+{
+    /**
+     * @dataProvider provider
+     */
+    public function test_it_handles_dataproviders() {
+        $this->assertTrue(true, 'It lets the test cases run normally');
+    }
+
+    public function provider() {
+        // This is just a dummy data provider
+        yield [1];
+    }
+}


### PR DESCRIPTION
The BeforeTestHook gets a description of the TestCase.
Without data providers, it looks like this:

    "App\Tests\MyTest::it_should_work"

However, with a data provider, it looks like this:

    "App\Tests\MyTest::it_should_work with data set #0 ('...')"

Splitting by "::" alone will not properly extract the method name
and thus fail to load the annotations.

<!--
Please read the CONTRIBUTING.md to learn about contributing to this project.

Please also note that this project is released with a Contributor Code of Conduct.
By participating in this project you agree to abide by its terms.
The Code of Conduct can be found in CODE_OF_CONDUCT.md.
-->

