### PR TITLE
Unset Vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.php_cs.cache
+/.php-cs-fixer.cache
 /.phpunit.result.cache
 /box.json
 /build/

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,21 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 $finder = PhpCsFixer\Finder::create()
     ->in(['src', 'tests'])
 ;
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
         'blank_line_before_statement' => true,
         'declare_strict_types' => true,
-        'native_function_invocation' => true,
+        'native_function_invocation' => ['include' => ['@internal']],
         'no_empty_comment' => true,
         'no_empty_phpdoc' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'no_extra_consecutive_blank_lines' => true,
+        'no_extra_blank_lines' => true,
         'no_leading_import_slash' => true,
         'no_leading_namespace_whitespace' => true,
         'no_unused_imports' => true,
@@ -30,5 +32,5 @@ return PhpCsFixer\Config::create()
         'yoda_style' => true,
     ])
     ->setFinder($finder)
+    ->setRiskyAllowed(true)
 ;
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IS_PHP81:=$(shell php -r 'echo (int)version_compare(PHP_VERSION, "8.1", ">=");')
+IS_PHP73:=$(shell php -r 'echo (int)version_compare(PHP_VERSION, "7.4", "<");')
 
 default: build
 
@@ -31,7 +31,7 @@ test-package: test-package-tools
 	cd tests/phar && ./tools/phpunit
 .PHONY: test-package
 
-ifeq ($(IS_PHP81),1)
+ifeq ($(IS_PHP73),1)
 cs:
 else
 cs: tools/php-cs-fixer
@@ -39,7 +39,7 @@ cs: tools/php-cs-fixer
 endif
 .PHONY: cs
 
-ifeq ($(IS_PHP81),1)
+ifeq ($(IS_PHP73),1)
 cs-fix:
 else
 cs-fix: tools/php-cs-fixer
@@ -88,7 +88,7 @@ tools/phpunit: vendor/bin/phpunit
 	ln -sf ../vendor/bin/phpunit tools/phpunit
 
 tools/php-cs-fixer:
-	curl -Ls http://cs.symfony.com/download/php-cs-fixer-v2.phar -o tools/php-cs-fixer && chmod +x tools/php-cs-fixer
+	curl -Ls http://cs.symfony.com/download/php-cs-fixer-v3.phar -o tools/php-cs-fixer && chmod +x tools/php-cs-fixer
 
 tools/box:
 	curl -Ls https://github.com/humbug/box/releases/download/3.13.0/box.phar -o tools/box && chmod +x tools/box

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Allows to use annotations to define global variables in PHPUnit test cases.
 Supported annotations:
 
  * `@env` for `$_ENV`
- * `@server` for `$_SERVER` 
+ * `@server` for `$_SERVER`
  * `@putenv` for [`putenv()`](http://php.net/putenv)
 
 Global variables are set before each test case is executed,
@@ -85,6 +85,27 @@ class ExampleTest extends TestCase
         $this->assertSame('bar', $_SERVER['APP_ENV']);
         $this->assertSame('1', $_SERVER['APP_DEBUG']);
         $this->assertSame('localhost', \getenv('APP_HOST'));
+    }
+}
+```
+
+It's also possible to mark a variable as _unset_ so it will not be present in any of the global variables:
+
+```php
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
+{
+    /**
+     * @unset-env APP_ENV
+     * @unset-server APP_DEBUG
+     * @unset-getenv APP_HOST
+     */
+    public function test_global_variables()
+    {
+        $this->assertArrayNotHasKey('APP_ENV', $_ENV);
+        $this->assertArrayNotHasKey('APP_DEBUG', $_SERVER);
+        $this->assertArrayNotHasKey('APP_HOST', \getenv());
     }
 }
 ```

--- a/src/AnnotationExtension.php
+++ b/src/AnnotationExtension.php
@@ -49,13 +49,25 @@ class AnnotationExtension implements BeforeTestHook, AfterTestHook
         $globalVars = $this->parseGlobalAnnotations($test);
 
         foreach ($globalVars['env'] as $name => $value) {
-            $_ENV[$name] = $value;
+            if (false === $value) {
+                unset($_ENV[$name]);
+            } else {
+                $_ENV[$name] = $value;
+            }
         }
         foreach ($globalVars['server'] as $name => $value) {
-            $_SERVER[$name] = $value;
+            if (false === $value) {
+                unset($_SERVER[$name]);
+            } else {
+                $_SERVER[$name] = $value;
+            }
         }
         foreach ($globalVars['putenv'] as $name => $value) {
-            \putenv(\sprintf('%s=%s', $name, $value));
+            if (false === $value) {
+                \putenv($name);
+            } else {
+                \putenv(\sprintf('%s=%s', $name, $value));
+            }
         }
     }
 
@@ -63,7 +75,7 @@ class AnnotationExtension implements BeforeTestHook, AfterTestHook
     {
         return \array_map(function (array $annotations) {
             return \array_reduce($annotations, function ($carry, $annotation) {
-                list($name, $value) = \strpos($annotation, '=') ? \explode('=', $annotation, 2) : [$annotation, ''];
+                list($name, $value) = \strpos($annotation, '=') ? \explode('=', $annotation, 2) : [$annotation, false];
                 $carry[$name] = $value;
 
                 return $carry;

--- a/tests/AnnotationExtensionTest.php
+++ b/tests/AnnotationExtensionTest.php
@@ -77,6 +77,18 @@ class AnnotationExtensionTest extends TestCase
      */
     public function test_it_reads_empty_vars()
     {
+        $this->assertArraySubset(['APP_ENV' => ''], $_ENV);
+        $this->assertArraySubset(['APP_DEBUG' => ''], $_SERVER);
+        $this->assertArraySubset(['APP_HOST' => ''], \getenv());
+    }
+
+    /**
+     * @unset-env APP_ENV
+     * @unset-server APP_DEBUG
+     * @unset-getenv APP_HOST
+     */
+    public function test_it_unsets_vars()
+    {
         $this->assertArrayNotHasKey('APP_ENV', $_ENV);
         $this->assertArrayNotHasKey('APP_DEBUG', $_SERVER);
         $this->assertArrayNotHasKey('APP_HOST', \getenv());

--- a/tests/AnnotationExtensionTest.php
+++ b/tests/AnnotationExtensionTest.php
@@ -77,9 +77,9 @@ class AnnotationExtensionTest extends TestCase
      */
     public function test_it_reads_empty_vars()
     {
-        $this->assertArraySubset(['APP_ENV' => ''], $_ENV);
-        $this->assertArraySubset(['APP_DEBUG' => ''], $_SERVER);
-        $this->assertArraySubset(['APP_HOST' => ''], \getenv());
+        $this->assertArrayNotHasKey('APP_ENV', $_ENV);
+        $this->assertArrayNotHasKey('APP_DEBUG', $_SERVER);
+        $this->assertArrayNotHasKey('APP_HOST', \getenv());
     }
 
     public function test_it_backups_the_state()


### PR DESCRIPTION
Add new annotations `@unset-env`, `@unset-server`, and `@unset-getenv` to mark variables as unset for a test.
Bumped the version of PHP-CS-Fixer, and corresponding config file.