### PR TITLE
Add attribute reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ Allows to use annotations to define global variables in PHPUnit test cases.
 
 [![Build](https://github.com/jakzal/phpunit-globals/actions/workflows/build.yml/badge.svg)](https://github.com/jakzal/phpunit-globals/actions/workflows/build.yml)
 
+Supported attributes:
+ * `#[Env]` for `$_ENV`
+ * `#[Server]` for `$_SERVER`
+ * `#[Putenv]` for [`putenv()`](http://php.net/putenv)
+
 Supported annotations:
 
- * `@env` for `$_ENV`
- * `@server` for `$_SERVER`
- * `@putenv` for [`putenv()`](http://php.net/putenv)
+ * `@env` and `@unset-env` for `$_ENV`
+ * `@server` and `@unset-server` for `$_SERVER`
+ * `@putenv` and `@unset-getenv` for [`putenv()`](http://php.net/putenv)
 
 Global variables are set before each test case is executed,
 and brought to the original state after each test case has finished.
@@ -39,7 +44,7 @@ Remember to instruct PHPUnit to load extensions in your `phpunit.xml`:
 
 ## Usage
 
-Enable the globals annotation extension in your PHPUnit configuration:
+Enable the globals attribute extension in your PHPUnit configuration:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -51,31 +56,33 @@ Enable the globals annotation extension in your PHPUnit configuration:
     <!-- ... -->
 
     <extensions>
-        <bootstrap class="Zalas\PHPUnit\Globals\AnnotationExtension" />
+        <bootstrap class="Zalas\PHPUnit\Globals\AttributeExtension" />
     </extensions>
-
 </phpunit>
 ```
 
-Make sure the `AnnotationExtension` is registered before any other extensions that might depend on global variables.
+> If you are using a version before PHP 8.1 you can use the `AnnotationExtension` instead.
 
-Global variables can now be defined in annotations:
+Make sure the `AttributeExtension` is registered before any other extensions that might depend on global variables.
+
+Global variables can now be defined in attributes:
 
 ```php
 use PHPUnit\Framework\TestCase;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+use Zalas\PHPUnit\Globals\Attribute\Server;
+use Zalas\PHPUnit\Globals\Attribute\Putenv;
 
 /**
  * @env FOO=bar
  */
 class ExampleTest extends TestCase
 {
-    /**
-     * @env APP_ENV=foo
-     * @env APP_DEBUG=0
-     * @server APP_ENV=bar
-     * @server APP_DEBUG=1
-     * @putenv APP_HOST=localhost
-     */
+    #[Env('APP_ENV', 'foo')]
+    #[Env('APP_DEBUG', '0')]
+    #[Server('APP_ENV', 'bar')]
+    #[Server('APP_DEBUG', '1')]
+    #[Putenv('APP_HOST', 'localhost')]
     public function test_global_variables()
     {
         $this->assertSame('bar', $_ENV['FOO']);
@@ -95,11 +102,9 @@ use PHPUnit\Framework\TestCase;
 
 class ExampleTest extends TestCase
 {
-    /**
-     * @unset-env APP_ENV
-     * @unset-server APP_DEBUG
-     * @unset-getenv APP_HOST
-     */
+    #[Env('APP_ENV', unset: true)]
+    #[Server('APP_DEBUG', unset: true)]
+    #[Putenv('APP_HOST', unset: true)]
     public function test_global_variables()
     {
         $this->assertArrayNotHasKey('APP_ENV', $_ENV);
@@ -115,7 +120,7 @@ replace the extension registration in `phpunit.xml`:
 
 ```xml
     <extensions>
-        <extension class="Zalas\PHPUnit\Globals\AnnotationExtension" />
+        <extension class="Zalas\PHPUnit\Globals\AttributeExtension" />
     </extensions>
 ```
 
@@ -123,7 +128,7 @@ with:
 
 ```xml
     <extensions>
-        <bootstrap class="Zalas\PHPUnit\Globals\AnnotationExtension" />
+        <bootstrap class="Zalas\PHPUnit\Globals\AttributeExtension" />
     </extensions>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHPUnit Globals
 
-Allows to use annotations to define global variables in PHPUnit test cases.
+Allows to use attributes to define global variables in PHPUnit test cases.
 
 [![Build](https://github.com/jakzal/phpunit-globals/actions/workflows/build.yml/badge.svg)](https://github.com/jakzal/phpunit-globals/actions/workflows/build.yml)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zalas/phpunit-globals",
-    "description": "Allows to use annotations to define global variables in PHPUnit test cases.",
+    "description": "Allows to use attributes to define global variables in PHPUnit test cases.",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,6 @@
     <env name="USER" value="test" force="true"/>
   </php>
   <extensions>
-    <bootstrap class="Zalas\PHPUnit\Globals\AnnotationExtension" />
+    <bootstrap class="Zalas\PHPUnit\Globals\Tests\Stub\CombinedExtension" />
   </extensions>
 </phpunit>

--- a/src/Attribute/Env.php
+++ b/src/Attribute/Env.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class Env
+{
+    use TargetAware;
+
+    public function __construct(
+        public readonly string $name,
+        public readonly string $value = '',
+        public readonly bool $unset = false,
+    ) {
+    }
+}

--- a/src/Attribute/Putenv.php
+++ b/src/Attribute/Putenv.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class Putenv
+{
+    use TargetAware;
+
+    public function __construct(
+        public readonly string $name,
+        public readonly string $value = '',
+        public readonly bool $unset = false,
+    ) {
+    }
+}

--- a/src/Attribute/Server.php
+++ b/src/Attribute/Server.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class Server
+{
+    use TargetAware;
+
+    public function __construct(
+        public readonly string $name,
+        public readonly string $value = '',
+        public readonly bool $unset = false,
+    ) {
+    }
+}

--- a/src/Attribute/TargetAware.php
+++ b/src/Attribute/TargetAware.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals\Attribute;
+
+trait TargetAware
+{
+    private int $target = 0;
+
+    /**
+     * @internal
+     */
+    public function withTarget(int $target): self
+    {
+        $clone = clone $this;
+        $clone->target = $target;
+
+        return $clone;
+    }
+
+    /**
+     * @internal
+     */
+    public function getTarget(): int
+    {
+        return $this->target;
+    }
+}

--- a/src/AttributeExtension.php
+++ b/src/AttributeExtension.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+final class AttributeExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $globalsBackup = new GlobalsBackup();
+        $globalsAttributeReader = new GlobalsAttributeReader();
+        $globalsRestoration = new GlobalsRestoration($globalsBackup);
+        $facade->registerSubscribers($globalsBackup, $globalsAttributeReader, $globalsRestoration);
+    }
+}

--- a/src/GlobalsAttributeReader.php
+++ b/src/GlobalsAttributeReader.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+use PHPUnit\Event\Code\TestMethod;
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+use Zalas\PHPUnit\Globals\Attribute\Putenv;
+use Zalas\PHPUnit\Globals\Attribute\Server;
+
+final class GlobalsAttributeReader implements PreparationStartedSubscriber
+{
+    public function notify(PreparationStarted $event): void
+    {
+        $this->readGlobalAttributes($event->test());
+    }
+
+    private function readGlobalAttributes(TestMethod $method): void
+    {
+        $attributes = $this->parseTestMethodAttributes($method);
+        $setVars = $this->findSetVarAttributes($attributes);
+
+        foreach ($setVars as $var) {
+            match (true) {
+                $var instanceof Env => $_ENV[$var->name] = $var->value,
+                $var instanceof Server => $_SERVER[$var->name] = $var->value,
+                $var instanceof Putenv => \putenv(\sprintf('%s=%s', $var->name, $var->value))
+            };
+        }
+
+        $unsetVars = $this->findUnsetVarAttributes($attributes);
+
+        foreach ($unsetVars as $var) {
+            $callable = match (true) {
+                $var instanceof Env => static function ($var) {
+                    unset($_ENV[$var->name]);
+                },
+                $var instanceof Server => static function ($var) {
+                    unset($_SERVER[$var->name]);
+                },
+                $var instanceof Putenv => static function ($var) {
+                    \putenv($var->name);
+                }
+            };
+
+            $callable($var);
+        }
+    }
+
+    /**
+     * @param array<Env|Putenv|Server> $attributes
+     */
+    private function findSetVarAttributes(array $attributes): array
+    {
+        $attributes = \array_filter(
+            $attributes,
+            static fn (Env|Server|Putenv $attribute) => false === $attribute->unset,
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        \usort($attributes, static fn (Env|Server|Putenv $a, Env|Server|Putenv $b) => $a->getTarget() <=> $b->getTarget());
+
+        return $attributes;
+    }
+
+    /**
+     * @param array<Env|Putenv|Server> $attributes
+     */
+    private function findUnsetVarAttributes(array $attributes): array
+    {
+        $attributes = \array_filter(
+            $attributes,
+            static fn (Env|Server|Putenv $attribute) => true === $attribute->unset,
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        \usort($attributes, static fn (Env|Server|Putenv $a, Env|Server|Putenv $b) => $a->getTarget() <=> $b->getTarget());
+
+        return $attributes;
+    }
+
+    /**
+     * @return array<Env|Putenv|Server>
+     */
+    private function parseTestMethodAttributes(TestMethod $method): array
+    {
+        $className = $method->className();
+        $methodName = $method->methodName();
+
+        $methodAttributes = null;
+
+        if (null !== $methodName) {
+            $methodAttributes = $this->collectGlobalsFromAttributes(
+                (new \ReflectionMethod($className, $methodName))->getAttributes()
+            );
+        }
+
+        return \array_merge(
+            $methodAttributes,
+            $this->collectGlobalsFromAttributes((new \ReflectionClass($className))->getAttributes())
+        );
+    }
+
+    /**
+     * @param array<\ReflectionAttribute> $attributes
+     * @return array<Env|Putenv|Server>
+     */
+    private function collectGlobalsFromAttributes(array $attributes): array
+    {
+        $globals = [];
+
+        foreach ($attributes as $attribute) {
+            if (!\str_starts_with($attribute->getName(), 'Zalas\\PHPUnit\\Globals\\Attribute\\')) {
+                continue;
+            }
+
+            /** @var Env|Server|Putenv $instance */
+            $instance = $attribute->newInstance();
+            $globals[] = $instance->withTarget($attribute->getTarget());
+        }
+
+        return $globals;
+    }
+}

--- a/tests/AttributeExtensionNoAnnotationsTest.php
+++ b/tests/AttributeExtensionNoAnnotationsTest.php
@@ -6,9 +6,9 @@ namespace Zalas\PHPUnit\Globals\Tests;
 use PHPUnit\Framework\TestCase;
 
 /**
- * A test case with no global variable annotations.
+ * A test case with no global variable attributes.
  */
-class AnnotationExtensionNoAnnotationsTest extends TestCase
+class AttributeExtensionNoAnnotationsTest extends TestCase
 {
     public function test_it_backups_the_state()
     {

--- a/tests/AttributeExtensionNoAttributesTest.php
+++ b/tests/AttributeExtensionNoAttributesTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * A test case with no global variable attributes.
  */
-class AttributeExtensionNoAnnotationsTest extends TestCase
+class AttributeExtensionNoAttributesTest extends TestCase
 {
     public function test_it_backups_the_state()
     {

--- a/tests/AttributeExtensionTest.php
+++ b/tests/AttributeExtensionTest.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 namespace Zalas\PHPUnit\Globals\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+use Zalas\PHPUnit\Globals\Attribute\Putenv;
+use Zalas\PHPUnit\Globals\Attribute\Server;
 
-/**
- * @env AVAILABLE_IN_SETUP=foo
- * @env APP_ENV=test
- * @server APP_DEBUG=0
- * @putenv APP_HOST=localhost
- */
-class AnnotationExtensionTest extends TestCase
+#[Env('AVAILABLE_IN_SETUP', 'foo')]
+#[Env('APP_ENV', 'test')]
+#[Server('APP_DEBUG', '0')]
+#[Putenv('APP_HOST', 'localhost')]
+class AttributeExtensionTest extends TestCase
 {
     protected function setUp(): void
     {
@@ -21,30 +22,26 @@ class AnnotationExtensionTest extends TestCase
         self::assertSame('foo', $_ENV['AVAILABLE_IN_SETUP']);
     }
 
-    /**
-     * @env APP_ENV=test_foo
-     * @server APP_DEBUG=1
-     * @putenv APP_HOST=dev
-     */
-    public function test_it_reads_global_variables_from_method_annotations(): void
+    #[Env('APP_ENV', 'test_foo')]
+    #[Server('APP_DEBUG', '1')]
+    #[Putenv('APP_HOST', 'dev')]
+    public function test_it_reads_global_variables_from_method_attributes(): void
     {
         self::assertArraySubset(['APP_ENV' => 'test_foo'], $_ENV);
         self::assertArraySubset(['APP_DEBUG' => '1'], $_SERVER);
         self::assertArraySubset(['APP_HOST' => 'dev'], \getenv());
     }
 
-    public function test_it_reads_global_variables_from_class_annotations(): void
+    public function test_it_reads_global_variables_from_class_attributes(): void
     {
         self::assertArraySubset(['APP_ENV' => 'test'], $_ENV);
         self::assertArraySubset(['APP_DEBUG' => '0'], $_SERVER);
         self::assertArraySubset(['APP_HOST' => 'localhost'], \getenv());
     }
 
-    /**
-     * @env FOO=foo
-     * @server BAR=bar
-     * @putenv BAZ=baz
-     */
+    #[Env('FOO', 'foo')]
+    #[Server('BAR', 'bar')]
+    #[Putenv('BAZ', 'baz')]
     public function test_it_reads_additional_global_variables_from_methods(): void
     {
         self::assertArraySubset(['APP_ENV' => 'test'], $_ENV);
@@ -55,14 +52,12 @@ class AnnotationExtensionTest extends TestCase
         self::assertArraySubset(['BAZ' => 'baz'], \getenv());
     }
 
-    /**
-     * @env APP_ENV=test_foo
-     * @env APP_ENV=test_foo_bar
-     * @server APP_DEBUG=1
-     * @server APP_DEBUG=2
-     * @putenv APP_HOST=host1
-     * @putenv APP_HOST=host2
-     */
+    #[Env('APP_ENV', 'test_foo')]
+    #[Env('APP_ENV', 'test_foo_bar')]
+    #[Server('APP_DEBUG', '1')]
+    #[Server('APP_DEBUG', '2')]
+    #[Putenv('APP_HOST', 'host1')]
+    #[Putenv('APP_HOST', 'host2')]
     public function test_it_reads_the_latest_var_defined(): void
     {
         self::assertArraySubset(['APP_ENV' => 'test_foo_bar'], $_ENV);
@@ -70,11 +65,9 @@ class AnnotationExtensionTest extends TestCase
         self::assertArraySubset(['APP_HOST' => 'host2'], \getenv());
     }
 
-    /**
-     * @env APP_ENV
-     * @server APP_DEBUG
-     * @putenv APP_HOST
-     */
+    #[Env('APP_ENV')]
+    #[Server('APP_DEBUG')]
+    #[Putenv('APP_HOST')]
     public function test_it_reads_empty_vars(): void
     {
         self::assertArraySubset(['APP_ENV' => ''], $_ENV);
@@ -82,12 +75,10 @@ class AnnotationExtensionTest extends TestCase
         self::assertArraySubset(['APP_HOST' => ''], \getenv());
     }
 
-    /**
-     * @unset-env APP_ENV
-     * @unset-server APP_DEBUG
-     * @unset-getenv APP_HOST
-     * @unset-env USER
-     */
+    #[Env('APP_ENV', unset: true)]
+    #[Server('APP_DEBUG', unset: true)]
+    #[Putenv('APP_HOST', unset: true)]
+    #[Env('USER', unset: true)]
     public function test_it_unsets_vars(): void
     {
         $this->assertArrayNotHasKey('USER', $_ENV);

--- a/tests/AttributeExtensionWithDataProviderTest.php
+++ b/tests/AttributeExtensionWithDataProviderTest.php
@@ -5,7 +5,7 @@ namespace Zalas\PHPUnit\Globals\Tests;
 
 use PHPUnit\Framework\TestCase;
 
-class AnnotationExtensionWithDataProviderTest extends TestCase
+class AttributeExtensionWithDataProviderTest extends TestCase
 {
     /**
      * @dataProvider provider

--- a/tests/Stub/CombinedExtension.php
+++ b/tests/Stub/CombinedExtension.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals\Tests\Stub;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+use Zalas\PHPUnit\Globals\GlobalsAnnotationReader;
+use Zalas\PHPUnit\Globals\GlobalsAttributeReader;
+use Zalas\PHPUnit\Globals\GlobalsBackup;
+use Zalas\PHPUnit\Globals\GlobalsRestoration;
+
+final class CombinedExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $globalsBackup = new GlobalsBackup();
+        $globalsAttributeReader = new GlobalsAttributeReader();
+        $globalsAnnotationReader = new GlobalsAnnotationReader();
+        $globalsRestoration = new GlobalsRestoration($globalsBackup);
+        $facade->registerSubscribers(
+            $globalsBackup,
+            $globalsAttributeReader,
+            $globalsAnnotationReader,
+            $globalsRestoration
+        );
+    }
+}

--- a/tests/phar/phpunit.xml
+++ b/tests/phar/phpunit.xml
@@ -11,6 +11,6 @@
     </testsuites>
 
     <extensions>
-        <bootstrap class="Zalas\PHPUnit\Globals\AnnotationExtension" />
+        <bootstrap class="Zalas\PHPUnit\Globals\Tests\Stub\CombinedExtension" />
     </extensions>
 </phpunit>

--- a/tests/phar/tests/PharTest.php
+++ b/tests/phar/tests/PharTest.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+use Zalas\PHPUnit\Globals\Attribute\Server;
 
 class PharTest extends TestCase
 {
@@ -10,6 +12,14 @@ class PharTest extends TestCase
      * @server APP_DEBUG=1
      */
     public function test_it_reads_global_variables_from_method_annotations()
+    {
+        $this->assertArraySubset(['APP_ENV' => 'test_foo'], $_ENV);
+        $this->assertArraySubset(['APP_DEBUG' => '1'], $_SERVER);
+    }
+
+    #[Env("APP_ENV", "test_foo")]
+    #[Server("APP_DEBUG", "1")]
+    public function test_it_reads_global_variables_from_method_attributes()
     {
         $this->assertArraySubset(['APP_ENV' => 'test_foo'], $_ENV);
         $this->assertArraySubset(['APP_DEBUG' => '1'], $_SERVER);


### PR DESCRIPTION
Solves #25 

This is a basic straight forward implementation to support attributes.
The attributes are provided by this package, as we can't rely on PHPUnit attribute parser implementation which is tied to its own attributes.