### PR TITLE
Phpunit10 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,10 @@ jobs:
         name: Build and test
         strategy:
             matrix:
-                php: [8.0, 8.1, 8.2]
+                php: [8.1, 8.2]
                 deps: [high]
                 include:
-                    -   php: 8.0
+                    -   php: 8.1
                         deps: low
 
         steps:
@@ -45,7 +45,7 @@ jobs:
 
             -   name: Upload the phar
                 uses: actions/upload-artifact@v1
-                if: matrix.php == '8.0' && matrix.deps == 'high'
+                if: matrix.php == '8.1' && matrix.deps == 'high'
                 with:
                     name: zalas-phpunit-globals-extension.phar
                     path: build/zalas-phpunit-globals-extension.phar
@@ -56,7 +56,7 @@ jobs:
         needs: tests
         strategy:
             matrix:
-                php: [8.0, 8.1, 8.2]
+                php: [8.1, 8.2]
 
         steps:
             -   uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,8 @@
         }
     ],
     "require": {
-        "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
-        "phpunit/phpunit": "^9.0"
-    },
-    "conflict": {
-        "phpunit/phpunit": "9.5.0"
+        "php": "~8.1.0 || ~8.2.0",
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" colors="true" verbose="true">
-  <coverage processUncoveredFiles="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" colors="true" >
+  <coverage>
     <include>
       <directory suffix=".php">src</directory>
     </include>
@@ -13,6 +13,6 @@
     <env name="USER" value="test" force="true"/>
   </php>
   <extensions>
-    <extension class="Zalas\PHPUnit\Globals\AnnotationExtension"/>
+    <bootstrap class="Zalas\PHPUnit\Globals\Extension"/>
   </extensions>
 </phpunit>

--- a/src/Context.php
+++ b/src/Context.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+final class Context
+{
+    public function __construct(
+        private array $server = [],
+        private array $env = [],
+        private array|string|false $getenv = [],
+    ) {
+    }
+
+    public function backupGlobals(): void
+    {
+        $this->server = $_SERVER;
+        $this->env = $_ENV;
+        $this->getenv = \getenv();
+    }
+
+    public function getServer(): array
+    {
+        return $this->server;
+    }
+
+    public function getEnv(): array
+    {
+        return $this->env;
+    }
+
+    public function getGetenv(): bool|array|string
+    {
+        return $this->getenv;
+    }
+}

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+use PHPUnit\Runner\Extension\Extension as PhpunitExtension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+final class Extension implements PhpunitExtension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $context = new Context();
+
+        $facade->registerSubscriber(new PrepareTestEnvironmentSubscriber($context));
+        $facade->registerSubscriber(new RestoreEnvironmentGlobalsSubscriber($context));
+    }
+}

--- a/src/RestoreEnvironmentGlobalsSubscriber.php
+++ b/src/RestoreEnvironmentGlobalsSubscriber.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+
+final class RestoreEnvironmentGlobalsSubscriber implements FinishedSubscriber
+{
+    public function __construct(
+        private readonly Context $context,
+    ) {
+    }
+
+    public function notify(Finished $event): void
+    {
+        $_SERVER = $this->context->getServer();
+        $_ENV = $this->context->getEnv();
+
+        foreach (\array_diff_assoc($this->context->getGetenv(), \getenv()) as $name => $value) {
+            \putenv(\sprintf('%s=%s', $name, $value));
+        }
+        foreach (\array_diff_assoc(\getenv(), $this->context->getGetenv()) as $name => $value) {
+            \putenv($name);
+        }
+    }
+}

--- a/tests/ExtensionNoAnnotationsTest.php
+++ b/tests/ExtensionNoAnnotationsTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * A test case with no global variable annotations.
  */
-class AnnotationExtensionNoAnnotationsTest extends TestCase
+class ExtensionNoAnnotationsTest extends TestCase
 {
     public function test_it_backups_the_state()
     {

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -3,22 +3,24 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals\Tests;
 
+use PHPUnit\Event\Test\FinishedSubscriber;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\AfterTestHook;
-use PHPUnit\Runner\BeforeTestHook;
-use Zalas\PHPUnit\Globals\AnnotationExtension;
+use Zalas\PHPUnit\Globals\Context;
+use Zalas\PHPUnit\Globals\PrepareTestEnvironmentSubscriber;
+use Zalas\PHPUnit\Globals\RestoreEnvironmentGlobalsSubscriber;
 
 /**
  * @env APP_ENV=test
  * @server APP_DEBUG=0
  * @putenv APP_HOST=localhost
  */
-class AnnotationExtensionTest extends TestCase
+class ExtensionTest extends TestCase
 {
     public function test_it_is_a_test_hook()
     {
-        $this->assertInstanceOf(BeforeTestHook::class, new AnnotationExtension());
-        $this->assertInstanceOf(AfterTestHook::class, new AnnotationExtension());
+        $this->assertInstanceOf(PreparationStartedSubscriber::class, new PrepareTestEnvironmentSubscriber(new Context()));
+        $this->assertInstanceOf(FinishedSubscriber::class, new RestoreEnvironmentGlobalsSubscriber(new Context()));
     }
 
     /**

--- a/tests/ExtensionWithDataProviderTest.php
+++ b/tests/ExtensionWithDataProviderTest.php
@@ -5,7 +5,7 @@ namespace Zalas\PHPUnit\Globals\Tests;
 
 use PHPUnit\Framework\TestCase;
 
-class AnnotationExtensionWithDataProviderTest extends TestCase
+class ExtensionWithDataProviderTest extends TestCase
 {
     /**
      * @dataProvider provider
@@ -15,7 +15,7 @@ class AnnotationExtensionWithDataProviderTest extends TestCase
         $this->assertTrue(true, 'It lets the test cases run normally');
     }
 
-    public function provider()
+    public static function provider()
     {
         // This is just a dummy data provider
         yield [1];


### PR DESCRIPTION
Fix #33 

Upgrade the codebase to be compatible with PHPUnit 10.

* `BeforeTestHook` and `AfterTestHook` have been removed and replaced by [a subscriber mechnism](https://docs.phpunit.de/en/10.0/extending-phpunit.html)
* So I've introduced a `Context` class to share state between each subscriber
* I've removed PHP 8.0 compatibility as PHPUnit 10 requires at least PHP 8.1