### PR TITLE
fix: using globals in setUp()

### DIFF
--- a/src/GlobalsAnnotationReader.php
+++ b/src/GlobalsAnnotationReader.php
@@ -3,13 +3,13 @@
 namespace Zalas\PHPUnit\Globals;
 
 use PHPUnit\Event\Code\TestMethod;
-use PHPUnit\Event\Test\Prepared;
-use PHPUnit\Event\Test\PreparedSubscriber;
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
 use PHPUnit\Metadata\Annotation\Parser\Registry;
 
-final class GlobalsAnnotationReader implements PreparedSubscriber
+final class GlobalsAnnotationReader implements PreparationStartedSubscriber
 {
-    public function notify(Prepared $event): void
+    public function notify(PreparationStarted $event): void
     {
         $this->readGlobalAnnotations($event->test());
     }

--- a/src/GlobalsBackup.php
+++ b/src/GlobalsBackup.php
@@ -2,16 +2,16 @@
 
 namespace Zalas\PHPUnit\Globals;
 
-use PHPUnit\Event\Test\Prepared;
-use PHPUnit\Event\Test\PreparedSubscriber;
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
 
-final class GlobalsBackup implements PreparedSubscriber
+final class GlobalsBackup implements PreparationStartedSubscriber
 {
     private $server;
     private $env;
     private $getenv;
 
-    public function notify(Prepared $event): void
+    public function notify(PreparationStarted $event): void
     {
         $this->server = $_SERVER;
         $this->env = $_ENV;

--- a/tests/AnnotationExtensionTest.php
+++ b/tests/AnnotationExtensionTest.php
@@ -6,12 +6,21 @@ namespace Zalas\PHPUnit\Globals\Tests;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @env AVAILABLE_IN_SETUP=foo
  * @env APP_ENV=test
  * @server APP_DEBUG=0
  * @putenv APP_HOST=localhost
  */
 class AnnotationExtensionTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assertArrayHasKey('AVAILABLE_IN_SETUP', $_ENV);
+        $this->assertSame('foo', $_ENV['AVAILABLE_IN_SETUP']);
+    }
+
     /**
      * @env APP_ENV=test_foo
      * @server APP_DEBUG=1


### PR DESCRIPTION
In v2.5.0 you could set `@env` in the class doc and it would be available to use in `setUp()`. In v3.0.0 this behaviour has changed and annotations are only available in the test itself.

The order of event execution is as follows:
```php
\PHPUnit\Event\Application\Started
\PHPUnit\Event\TestRunner\Configured
\PHPUnit\Event\TestRunner\BootstrapFinished
\PHPUnit\Event\TestSuite\Loaded
\PHPUnit\Event\TestRunner\ExtensionBootstrapped
\PHPUnit\Event\TestRunner\EventFacadeSealed
\PHPUnit\Event\TestRunner\Started
\PHPUnit\Event\TestSuite\Sorted
\PHPUnit\Event\TestSuite\Filtered
\PHPUnit\Event\TestRunner\ExecutionStarted
\PHPUnit\Event\TestSuite\Started
\PHPUnit\Event\Test\PreparationStarted
## runs setUp()
\PHPUnit\Event\Test\BeforeTestMethodCalled
\PHPUnit\Event\Test\BeforeTestMethodFinished
\PHPUnit\Event\Test\Prepared
```
