### PR TITLE
Fix fatal error when an exception throws in PHPUnit

### DIFF
--- a/src/AnnotationExtension.php
+++ b/src/AnnotationExtension.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals;
 
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\AfterTestHook;
 use PHPUnit\Runner\BeforeTestHook;
 use PHPUnit\Util\Test;
@@ -121,7 +122,7 @@ class AnnotationExtension implements BeforeTestHook, AfterTestHook
     {
         $parts = \preg_split('/ |::/', $test);
 
-        if (!\class_exists($parts[0])) {
+        if (!\class_exists($parts[0]) || !\is_subclass_of($parts[0], TestCase::class)) {
             return [];
         }
 

--- a/src/AttributeExtension.php
+++ b/src/AttributeExtension.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals;
 
+use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\AfterTestHook;
 use PHPUnit\Runner\BeforeTestHook;
 use Zalas\PHPUnit\Globals\Attribute\Env;
@@ -128,7 +129,7 @@ final class AttributeExtension implements BeforeTestHook, AfterTestHook
     {
         $parts = \preg_split('/ |::/', $test);
 
-        if (!\class_exists($parts[0])) {
+        if (!\class_exists($parts[0]) || !\is_subclass_of($parts[0], TestCase::class)) {
             return [];
         }
 


### PR DESCRIPTION
In one project using this library, we've got this error:

> PHPUnit\Util\Annotation\DocBlock::__construct(): Argument #4 ($startLine) must be of type int, bool given, called in /src/vendor/phpunit/phpunit/src/Util/Annotation/DocBlock.php on line 124

In our case, a developer made a mistake in a data provider and an exception has been throws.
But the exception goes back to the `AnnotationExtension` or the `AttributeExtension` and thoses classes trying to read data from the exception with `Test::parseTestMethodAnnotations(...$parts)`.

So this error generates the previous error.

I suggest to parse data only if the extension process a `TestCase` instance.