### PR TITLE
Fix tests on 2.6 branch

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,6 @@
     <env name="USER" value="test" force="true"/>
   </php>
   <extensions>
-    <extension class="Zalas\PHPUnit\Globals\AnnotationExtension"/>
-    <extension class="Zalas\PHPUnit\Globals\AttributeExtension"/>
+    <extension class="Zalas\PHPUnit\Globals\Tests\Stub\CombinedExtension"/>
   </extensions>
 </phpunit>

--- a/src/AnnotationExtension.php
+++ b/src/AnnotationExtension.php
@@ -3,130 +3,19 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\AfterTestHook;
 use PHPUnit\Runner\BeforeTestHook;
-use PHPUnit\Util\Test;
 
 class AnnotationExtension implements BeforeTestHook, AfterTestHook
 {
-    private $server;
-    private $env;
-    private $getenv;
-
     public function executeBeforeTest(string $test): void
     {
-        $this->backupGlobals();
-        $this->readGlobalAnnotations($test);
+        GlobalsContainer::getInstance()->backupGlobals();
+        AnnotationReader::getInstance()->readGlobalAnnotations($test);
     }
 
     public function executeAfterTest(string $test, float $time): void
     {
-        $this->restoreGlobals();
-    }
-
-    private function backupGlobals(): void
-    {
-        $this->server = $_SERVER;
-        $this->env = $_ENV;
-        $this->getenv = \getenv();
-    }
-
-    private function restoreGlobals(): void
-    {
-        $_SERVER = $this->server;
-        $_ENV = $this->env;
-
-        foreach (\array_diff_assoc($this->getenv, \getenv()) as $name => $value) {
-            \putenv(\sprintf('%s=%s', $name, $value));
-        }
-        foreach (\array_diff_assoc(\getenv(), $this->getenv) as $name => $value) {
-            \putenv($name);
-        }
-    }
-
-    private function readGlobalAnnotations(string $test)
-    {
-        $globalVars = $this->parseGlobalAnnotations($test);
-
-        foreach ($globalVars['env'] as $name => $value) {
-            $_ENV[$name] = $value;
-        }
-        foreach ($globalVars['server'] as $name => $value) {
-            $_SERVER[$name] = $value;
-        }
-        foreach ($globalVars['putenv'] as $name => $value) {
-            \putenv(\sprintf('%s=%s', $name, $value));
-        }
-
-        $unsetVars = $this->findUnsetVarAnnotations($test);
-
-        foreach ($unsetVars['unset-env'] as $name) {
-            unset($_ENV[$name]);
-        }
-        foreach ($unsetVars['unset-server'] as $name) {
-            unset($_SERVER[$name]);
-        }
-        foreach ($unsetVars['unset-getenv'] as $name) {
-            \putenv($name);
-        }
-    }
-
-    private function parseGlobalAnnotations(string $test): array
-    {
-        return \array_map(function (array $annotations) {
-            return \array_reduce($annotations, function ($carry, $annotation) {
-                list($name, $value) = \strpos($annotation, '=') ? \explode('=', $annotation, 2) : [$annotation, ''];
-                $carry[$name] = $value;
-
-                return $carry;
-            }, []);
-        }, $this->findSetVarAnnotations($test));
-    }
-
-    private function findSetVarAnnotations(string $test): array
-    {
-        $annotations = $this->parseTestMethodAnnotations($test);
-
-        return \array_filter(
-            \array_merge_recursive(
-                ['env' => [], 'server' => [], 'putenv' => []],
-                $annotations['class'] ?? [],
-                $annotations['method'] ?? []
-            ),
-            function (string $annotationName) {
-                return \in_array($annotationName, ['env', 'server', 'putenv']);
-            },
-            ARRAY_FILTER_USE_KEY
-        );
-    }
-
-    private function findUnsetVarAnnotations(string $test): array
-    {
-        $annotations = $this->parseTestMethodAnnotations($test);
-
-        return \array_filter(
-            \array_merge_recursive(
-                ['unset-env' => [], 'unset-server' => [], 'unset-getenv' => []],
-                $annotations['class'] ?? [],
-                $annotations['method'] ?? []
-            ),
-            function (string $annotationName) {
-                return \in_array($annotationName, ['unset-env', 'unset-server', 'unset-getenv']);
-            },
-            ARRAY_FILTER_USE_KEY
-        );
-    }
-
-    private function parseTestMethodAnnotations(string $test): array
-    {
-        $parts = \preg_split('/ |::/', $test);
-
-        if (!\class_exists($parts[0]) || !\is_subclass_of($parts[0], TestCase::class)) {
-            return [];
-        }
-
-        // @see PHPUnit\Framework\TestCase::getAnnotations
-        return Test::parseTestMethodAnnotations(...$parts);
+        GlobalsContainer::getInstance()->restoreGlobals();
     }
 }

--- a/src/AnnotationReader.php
+++ b/src/AnnotationReader.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Test;
+
+class AnnotationReader
+{
+    use SingletonTrait;
+
+    public function readGlobalAnnotations(string $test)
+    {
+        $globalVars = $this->parseGlobalAnnotations($test);
+
+        foreach ($globalVars['env'] as $name => $value) {
+            $_ENV[$name] = $value;
+        }
+        foreach ($globalVars['server'] as $name => $value) {
+            $_SERVER[$name] = $value;
+        }
+        foreach ($globalVars['putenv'] as $name => $value) {
+            \putenv(\sprintf('%s=%s', $name, $value));
+        }
+
+        $unsetVars = $this->findUnsetVarAnnotations($test);
+
+        foreach ($unsetVars['unset-env'] as $name) {
+            unset($_ENV[$name]);
+        }
+        foreach ($unsetVars['unset-server'] as $name) {
+            unset($_SERVER[$name]);
+        }
+        foreach ($unsetVars['unset-getenv'] as $name) {
+            \putenv($name);
+        }
+    }
+
+    private function parseGlobalAnnotations(string $test): array
+    {
+        return \array_map(function (array $annotations) {
+            return \array_reduce($annotations, function ($carry, $annotation) {
+                list($name, $value) = \strpos($annotation, '=') ? \explode('=', $annotation, 2) : [$annotation, ''];
+                $carry[$name] = $value;
+
+                return $carry;
+            }, []);
+        }, $this->findSetVarAnnotations($test));
+    }
+
+    private function findSetVarAnnotations(string $test): array
+    {
+        $annotations = $this->parseTestMethodAnnotations($test);
+
+        return \array_filter(
+            \array_merge_recursive(
+                ['env' => [], 'server' => [], 'putenv' => []],
+                $annotations['class'] ?? [],
+                $annotations['method'] ?? []
+            ),
+            function (string $annotationName) {
+                return \in_array($annotationName, ['env', 'server', 'putenv']);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    private function findUnsetVarAnnotations(string $test): array
+    {
+        $annotations = $this->parseTestMethodAnnotations($test);
+
+        return \array_filter(
+            \array_merge_recursive(
+                ['unset-env' => [], 'unset-server' => [], 'unset-getenv' => []],
+                $annotations['class'] ?? [],
+                $annotations['method'] ?? []
+            ),
+            function (string $annotationName) {
+                return \in_array($annotationName, ['unset-env', 'unset-server', 'unset-getenv']);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    private function parseTestMethodAnnotations(string $test): array
+    {
+        $parts = \preg_split('/ |::/', $test);
+
+        if (!\class_exists($parts[0]) || !\is_subclass_of($parts[0], TestCase::class)) {
+            return [];
+        }
+
+        // @see PHPUnit\Framework\TestCase::getAnnotations
+        return Test::parseTestMethodAnnotations(...$parts);
+    }
+}

--- a/src/AttributeExtension.php
+++ b/src/AttributeExtension.php
@@ -3,163 +3,19 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\AfterTestHook;
 use PHPUnit\Runner\BeforeTestHook;
-use Zalas\PHPUnit\Globals\Attribute\Env;
-use Zalas\PHPUnit\Globals\Attribute\Putenv;
-use Zalas\PHPUnit\Globals\Attribute\Server;
 
 final class AttributeExtension implements BeforeTestHook, AfterTestHook
 {
-    private $server;
-    private $env;
-    private $getenv;
-
     public function executeBeforeTest(string $test): void
     {
-        $this->backupGlobals();
-        $this->readGlobalAttributes($test);
+        GlobalsContainer::getInstance()->backupGlobals();
+        AttributeReader::getInstance()->readGlobalAttributes($test);
     }
 
     public function executeAfterTest(string $test, float $time): void
     {
-        $this->restoreGlobals();
-    }
-
-    private function backupGlobals(): void
-    {
-        $this->server = $_SERVER;
-        $this->env = $_ENV;
-        $this->getenv = \getenv();
-    }
-
-    private function restoreGlobals(): void
-    {
-        $_SERVER = $this->server;
-        $_ENV = $this->env;
-
-        foreach (\array_diff_assoc($this->getenv, \getenv()) as $name => $value) {
-            \putenv(\sprintf('%s=%s', $name, $value));
-        }
-        foreach (\array_diff_assoc(\getenv(), $this->getenv) as $name => $value) {
-            \putenv($name);
-        }
-    }
-
-    private function readGlobalAttributes(string $test)
-    {
-        $globalVars = $this->parseGlobalAttributes($test);
-
-        foreach ($globalVars['env'] as $name => $value) {
-            $_ENV[$name] = $value;
-        }
-        foreach ($globalVars['server'] as $name => $value) {
-            $_SERVER[$name] = $value;
-        }
-        foreach ($globalVars['putenv'] as $name => $value) {
-            \putenv(\sprintf('%s=%s', $name, $value));
-        }
-
-        $unsetVars = $this->findUnsetVarAttributes($test);
-
-        foreach ($unsetVars['unset-env'] as $name) {
-            unset($_ENV[$name]);
-        }
-        foreach ($unsetVars['unset-server'] as $name) {
-            unset($_SERVER[$name]);
-        }
-        foreach ($unsetVars['unset-getenv'] as $name) {
-            \putenv($name);
-        }
-    }
-
-    private function parseGlobalAttributes(string $test): array
-    {
-        $globals = ['env' => [], 'server' => [], 'putenv' => []];
-
-        $attributes = $this->findSetVarAttributes($test);
-        foreach ($attributes as $attribute) {
-            match (true) {
-                $attribute instanceof Env => $globals['env'][$attribute->name] = $attribute->value,
-                $attribute instanceof Server => $globals['server'][$attribute->name] = $attribute->value,
-                $attribute instanceof Putenv => $globals['putenv'][$attribute->name] = $attribute->value,
-            };
-        }
-
-        return $globals;
-    }
-
-    private function findSetVarAttributes(string $test): array
-    {
-        $attributes = $this->parseTestMethodAttributes($test);
-
-        $attributes = \array_filter(
-            $attributes,
-            static fn (Env|Server|Putenv $attribute) => false === $attribute->unset,
-            ARRAY_FILTER_USE_BOTH
-        );
-
-        \usort($attributes, static fn (Env|Server|Putenv $a, Env|Server|Putenv $b) => $a->getTarget() <=> $b->getTarget());
-
-        return $attributes;
-    }
-
-    private function findUnsetVarAttributes(string $test): array
-    {
-        $unset = ['unset-env' => [], 'unset-server' => [], 'unset-getenv' => []];
-
-        $attributes = $this->parseTestMethodAttributes($test);
-        foreach ($attributes as $attribute) {
-            if (false === $attribute->unset) {
-                continue;
-            }
-
-            match (true) {
-                $attribute instanceof Env => $unset['unset-env'][] = $attribute->name,
-                $attribute instanceof Server => $unset['unset-server'][] = $attribute->name,
-                $attribute instanceof Putenv => $unset['unset-getenv'][] = $attribute->name,
-            };
-        }
-
-        return $unset;
-    }
-
-    private function parseTestMethodAttributes(string $test): array
-    {
-        $parts = \preg_split('/ |::/', $test);
-
-        if (!\class_exists($parts[0]) || !\is_subclass_of($parts[0], TestCase::class)) {
-            return [];
-        }
-
-        $methodAttributes = [];
-        if (!empty($parts[1])) {
-            $methodAttributes = $this->collectGlobalsFromAttributes(
-                (new \ReflectionMethod($parts[0], $parts[1]))->getAttributes()
-            );
-        }
-
-        return \array_merge(
-            $this->collectGlobalsFromAttributes((new \ReflectionClass($parts[0]))->getAttributes()),
-            $methodAttributes,
-        );
-    }
-
-    private function collectGlobalsFromAttributes(array $attributes): array
-    {
-        $globals = [];
-
-        foreach ($attributes as $attribute) {
-            if (!\str_starts_with($attribute->getName(), 'Zalas\\PHPUnit\\Globals\\Attribute\\')) {
-                continue;
-            }
-
-            /** @var Env|Server|Putenv $instance */
-            $instance = $attribute->newInstance();
-            $globals[] = $instance->withTarget($attribute->getTarget());
-        }
-
-        return $globals;
+        GlobalsContainer::getInstance()->restoreGlobals();
     }
 }

--- a/src/AttributeReader.php
+++ b/src/AttributeReader.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+use PHPUnit\Framework\TestCase;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+use Zalas\PHPUnit\Globals\Attribute\Putenv;
+use Zalas\PHPUnit\Globals\Attribute\Server;
+
+final class AttributeReader
+{
+    use SingletonTrait;
+
+    public function readGlobalAttributes(string $test)
+    {
+        $globalVars = $this->parseGlobalAttributes($test);
+
+        foreach ($globalVars['env'] as $name => $value) {
+            $_ENV[$name] = $value;
+        }
+        foreach ($globalVars['server'] as $name => $value) {
+            $_SERVER[$name] = $value;
+        }
+        foreach ($globalVars['putenv'] as $name => $value) {
+            \putenv(\sprintf('%s=%s', $name, $value));
+        }
+
+        $unsetVars = $this->findUnsetVarAttributes($test);
+
+        foreach ($unsetVars['unset-env'] as $name) {
+            unset($_ENV[$name]);
+        }
+        foreach ($unsetVars['unset-server'] as $name) {
+            unset($_SERVER[$name]);
+        }
+        foreach ($unsetVars['unset-getenv'] as $name) {
+            \putenv($name);
+        }
+    }
+
+    private function parseGlobalAttributes(string $test): array
+    {
+        $globals = ['env' => [], 'server' => [], 'putenv' => []];
+
+        $attributes = $this->findSetVarAttributes($test);
+        foreach ($attributes as $attribute) {
+            match (true) {
+                $attribute instanceof Env => $globals['env'][$attribute->name] = $attribute->value,
+                $attribute instanceof Server => $globals['server'][$attribute->name] = $attribute->value,
+                $attribute instanceof Putenv => $globals['putenv'][$attribute->name] = $attribute->value,
+            };
+        }
+
+        return $globals;
+    }
+
+    private function findSetVarAttributes(string $test): array
+    {
+        $attributes = $this->parseTestMethodAttributes($test);
+
+        $attributes = \array_filter(
+            $attributes,
+            static fn (Env|Server|Putenv $attribute) => false === $attribute->unset,
+            ARRAY_FILTER_USE_BOTH
+        );
+
+        \usort($attributes, static fn (Env|Server|Putenv $a, Env|Server|Putenv $b) => $a->getTarget() <=> $b->getTarget());
+
+        return $attributes;
+    }
+
+    private function findUnsetVarAttributes(string $test): array
+    {
+        $unset = ['unset-env' => [], 'unset-server' => [], 'unset-getenv' => []];
+
+        $attributes = $this->parseTestMethodAttributes($test);
+        foreach ($attributes as $attribute) {
+            if (false === $attribute->unset) {
+                continue;
+            }
+
+            match (true) {
+                $attribute instanceof Env => $unset['unset-env'][] = $attribute->name,
+                $attribute instanceof Server => $unset['unset-server'][] = $attribute->name,
+                $attribute instanceof Putenv => $unset['unset-getenv'][] = $attribute->name,
+            };
+        }
+
+        return $unset;
+    }
+
+    private function parseTestMethodAttributes(string $test): array
+    {
+        $parts = \preg_split('/ |::/', $test);
+
+        if (!\class_exists($parts[0]) || !\is_subclass_of($parts[0], TestCase::class)) {
+            return [];
+        }
+
+        $methodAttributes = [];
+        if (!empty($parts[1])) {
+            $methodAttributes = $this->collectGlobalsFromAttributes(
+                (new \ReflectionMethod($parts[0], $parts[1]))->getAttributes()
+            );
+        }
+
+        return \array_merge(
+            $this->collectGlobalsFromAttributes((new \ReflectionClass($parts[0]))->getAttributes()),
+            $methodAttributes,
+        );
+    }
+
+    private function collectGlobalsFromAttributes(array $attributes): array
+    {
+        $globals = [];
+
+        foreach ($attributes as $attribute) {
+            if (!\str_starts_with($attribute->getName(), 'Zalas\\PHPUnit\\Globals\\Attribute\\')) {
+                continue;
+            }
+
+            /** @var Env|Server|Putenv $instance */
+            $instance = $attribute->newInstance();
+            $globals[] = $instance->withTarget($attribute->getTarget());
+        }
+
+        return $globals;
+    }
+}

--- a/src/GlobalsContainer.php
+++ b/src/GlobalsContainer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+final class GlobalsContainer
+{
+    use SingletonTrait;
+
+    private function __construct()
+    {
+    }
+
+    public function backupGlobals()
+    {
+        $this->server = $_SERVER;
+        $this->env = $_ENV;
+        $this->getenv = \getenv();
+    }
+
+    public function restoreGlobals()
+    {
+        $_SERVER = $this->server;
+        $_ENV = $this->env;
+
+        foreach (\array_diff_assoc($this->getenv, \getenv()) as $name => $value) {
+            \putenv(\sprintf('%s=%s', $name, $value));
+        }
+        foreach (\array_diff_assoc(\getenv(), $this->getenv) as $name => $value) {
+            \putenv($name);
+        }
+    }
+}

--- a/src/SingletonTrait.php
+++ b/src/SingletonTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals;
+
+trait SingletonTrait
+{
+    private static $instance = null;
+
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+}

--- a/tests/AnnotationExtensionTest.php
+++ b/tests/AnnotationExtensionTest.php
@@ -110,7 +110,7 @@ class AnnotationExtensionTest extends TestCase
     }
 
     /**
-     * @depends self::test_it_backups_the_state
+     * @depends test_it_backups_the_state
      */
     public function test_it_cleans_up_after_itself()
     {

--- a/tests/AttributeExtensionTest.php
+++ b/tests/AttributeExtensionTest.php
@@ -101,7 +101,7 @@ class AttributeExtensionTest extends TestCase
     }
 
     /**
-     * @depends self::test_it_backups_the_state
+     * @depends test_it_backups_the_state
      */
     public function test_it_cleans_up_after_itself()
     {

--- a/tests/Stub/CombinedExtension.php
+++ b/tests/Stub/CombinedExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zalas\PHPUnit\Globals\Tests\Stub;
+
+use PHPUnit\Runner\AfterTestHook;
+use PHPUnit\Runner\BeforeTestHook;
+use Zalas\PHPUnit\Globals\AnnotationReader;
+use Zalas\PHPUnit\Globals\AttributeReader;
+use Zalas\PHPUnit\Globals\GlobalsContainer;
+
+final class CombinedExtension implements BeforeTestHook, AfterTestHook
+{
+
+    public function executeBeforeTest(string $test): void
+    {
+        GlobalsContainer::getInstance()->backupGlobals();
+
+        AnnotationReader::getInstance()->readGlobalAnnotations($test);
+        AttributeReader::getInstance()->readGlobalAttributes($test);
+    }
+
+    public function executeAfterTest(string $test, float $time): void
+    {
+        GlobalsContainer::getInstance()->restoreGlobals();
+    }
+}


### PR DESCRIPTION
As notified in https://github.com/jakzal/phpunit-globals/pull/41#issuecomment-1500957882 tests currently emits a warning it cannot find the test to depend on.

It's because there's a conflict when running test with annotation and attributes at the same time.

So, like the main branch, I add a `CombinedExtension` to solve this problem and add a `GlobalsContainer` to store globals state.