### PR TITLE
Warning When Backing Up Globals

### DIFF
--- a/src/GlobalsContainer.php
+++ b/src/GlobalsContainer.php
@@ -8,6 +8,10 @@ final class GlobalsContainer
 {
     use SingletonTrait;
 
+    private array $server;
+    private array $env;
+    private array $getenv;
+
     private function __construct()
     {
     }

--- a/tests/Stub/CombinedExtension.php
+++ b/tests/Stub/CombinedExtension.php
@@ -12,7 +12,6 @@ use Zalas\PHPUnit\Globals\GlobalsContainer;
 
 final class CombinedExtension implements BeforeTestHook, AfterTestHook
 {
-
     public function executeBeforeTest(string $test): void
     {
         GlobalsContainer::getInstance()->backupGlobals();


### PR DESCRIPTION
Fix an issue in `GlobalsContainer` that would cause PHPUnit to output deprecation warnings.