### PR TITLE
Support for PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0 || ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AnnotationExtensionTest.php
+++ b/tests/AnnotationExtensionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals\Tests;
 
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -111,9 +112,7 @@ class AnnotationExtensionTest extends TestCase
         $this->assertSame('foobar', \getenv('USER'));
     }
 
-    /**
-     * @depends test_it_backups_the_state
-     */
+    #[Depends('test_it_backups_the_state')]
     public function test_it_cleans_up_after_itself(): void
     {
         $this->assertArrayNotHasKey('FOO', $_ENV);

--- a/tests/AttributeExtensionNoAttributesTest.php
+++ b/tests/AttributeExtensionNoAttributesTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals\Tests;
 
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,9 +22,7 @@ class AttributeExtensionNoAttributesTest extends TestCase
         $this->assertArrayHasKey('BAR', $_SERVER);
     }
 
-    /**
-     * @depends test_it_backups_the_state
-     */
+    #[Depends('test_it_backups_the_state')]
     public function test_it_cleans_up_after_itself()
     {
         $this->assertArrayNotHasKey('FOO', $_ENV);

--- a/tests/AttributeExtensionTest.php
+++ b/tests/AttributeExtensionTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals\Tests;
 
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use Zalas\PHPUnit\Globals\Attribute\Env;
 use Zalas\PHPUnit\Globals\Attribute\Putenv;
@@ -102,9 +103,7 @@ class AttributeExtensionTest extends TestCase
         $this->assertSame('foobar', \getenv('USER'));
     }
 
-    /**
-     * @depends test_it_backups_the_state
-     */
+    #[Depends('test_it_backups_the_state')]
     public function test_it_cleans_up_after_itself(): void
     {
         $this->assertArrayNotHasKey('FOO', $_ENV);

--- a/tests/AttributeExtensionWithDataProviderTest.php
+++ b/tests/AttributeExtensionWithDataProviderTest.php
@@ -3,13 +3,12 @@ declare(strict_types=1);
 
 namespace Zalas\PHPUnit\Globals\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class AttributeExtensionWithDataProviderTest extends TestCase
 {
-    /**
-     * @dataProvider provider
-     */
+    #[DataProvider('provider')]
     public function test_it_handles_dataproviders()
     {
         $this->assertTrue(true, 'It lets the test cases run normally');


### PR DESCRIPTION
I like this package very much and helps me setting up my test cases a lot better, so thanks for the work so far!

This package is bound to PHPUnit version 10 though, so I updated the composer dependency to also allow version 11.

I ran the tests and they succeeded (with PHPUnit version 11). I did also encounter some deprecated PHPUnit warnings, so I fixed them as well.

I am not sure if other code needs to be updated, but by the looks of it, and checking the PHPUnit documentation, I think the code is PHPUnit 11 compatible.


The deprecation warnings I got, that are now fixed:
```
There were 4 PHPUnit test runner deprecations:

1) Metadata found in doc-comment for method Zalas\PHPUnit\Globals\Tests\AnnotationExtensionTest::test_it_cleans_up_after_itself(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

2) Metadata found in doc-comment for method Zalas\PHPUnit\Globals\Tests\AttributeExtensionNoAttributesTest::test_it_cleans_up_after_itself(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

3) Metadata found in doc-comment for method Zalas\PHPUnit\Globals\Tests\AttributeExtensionTest::test_it_cleans_up_after_itself(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.

4) Metadata found in doc-comment for method Zalas\PHPUnit\Globals\Tests\AttributeExtensionWithDataProviderTest::test_it_handles_dataproviders(). Metadata in doc-comments is deprecated and will no longer be supported in PHPUnit 12. Update your test code to use attributes instead.
```